### PR TITLE
Support gorm like syntax for required, default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+.i # Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+.DS_Store
+tmp/
+data/
+.vscode/


### PR DESCRIPTION
* allow users to set `required`, which will result in an error if the EnvSet is missing the variable.
* allow users to set `default`, which provides a fallback value if the EnvSet is missing the variable.
* `parseTagSetting` is borrowed from Gorm: https://github.com/jinzhu/gorm/blob/2586a050160518363d91bd76b6b2a5a4b619d7c1/model_struct.go#L653

Let me know if you're interested in this and I can add to the readme.