### PR TITLE
Split default value only into two parts

### DIFF
--- a/env.go
+++ b/env.go
@@ -258,7 +258,7 @@ func parseTag(tagString string) tag {
 	envKeys := strings.Split(tagString, ",")
 	for _, key := range envKeys {
 		if strings.Contains(key, "=") {
-			keyData := strings.Split(key, "=")
+			keyData := strings.SplitN(key, "=", 2)
 			switch strings.ToLower(keyData[0]) {
 			case "default":
 				t.Default = keyData[1]

--- a/env_test.go
+++ b/env_test.go
@@ -66,6 +66,7 @@ type UnexportedStruct struct {
 
 type DefaultValueStruct struct {
 	DefaultString             string        `env:"MISSING_STRING,default=found"`
+	DefaultKeyValueString     string        `env:"MISSING_KVSTRING,default=key=value"`
 	DefaultBool               bool          `env:"MISSING_BOOL,default=true"`
 	DefaultInt                int           `env:"MISSING_INT,default=7"`
 	DefaultDuration           time.Duration `env:"MISSING_DURATION,default=5s"`
@@ -262,6 +263,7 @@ func TestUnmarshalDefaultValues(t *testing.T) {
 		{defaultValueStruct.DefaultInt, 7},
 		{defaultValueStruct.DefaultBool, true},
 		{defaultValueStruct.DefaultString, "found"},
+		{defaultValueStruct.DefaultKeyValueString, "key=value"},
 		{defaultValueStruct.DefaultDuration, 5 * time.Second},
 		{defaultValueStruct.DefaultWithOptionsMissing, "present"},
 		{defaultValueStruct.DefaultWithOptionsPresent, "youFoundMe"},


### PR DESCRIPTION
First, thanks for this really great go package!

Currently, i've a use case that requires an equals sign `=` in the default value.
For instance, the `struct` looks like this:

```
type Environment struct {
  Labels string `env:"LABELS,default=foo=bar"`
}
```

Unfortunately, this is currently not working properly...