### PR TITLE
Add support for custom env marshaling and unmarshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ func main() {
 }
 ```
 
-## Custom Unmarshaler
+## Custom Marshaler/Unmarshaler
 
-There is limited support for dictating how a field should be unmarshaled. The following example
-shows how you could unmarshal from JSON
+There is limited support for dictating how a field should be marshaled or unmarshaled. The following example
+shows how you could marshal/unmarshal from JSON
 
 ```go
 import (
@@ -101,6 +101,14 @@ func (s *SomeData) UnmarshalEnvironmentValue(data string) error {
 	return nil
 }
 
+func (s SomeData) MarshalEnvironmentValue() (string, error) {
+	bytes, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
 type Config struct {
     SomeData *SomeData `env:"SOME_DATA"`
 }
@@ -117,5 +125,11 @@ func main() {
     } else {
         fmt.Printf("Got nil or some other value: %v\n", cfg.SomeData)
     }
+
+    es, err = env.Marshal(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+    fmt.Printf("Got the following: %+v\n", es)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -72,3 +72,50 @@ func main() {
 	environment.Extras = es
 }
 ```
+
+## Custom Unmarshaler
+
+There is limited support for dictating how a field should be unmarshaled. The following example
+shows how you could unmarshal from JSON
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	
+    env "github.com/Netflix/go-env"
+)
+
+type SomeData struct {
+    SomeField int `json:"someField"`
+}
+
+func (s *SomeData) UnmarshalEnvironmentValue(data string) error {
+    var tmp SomeData
+    err := json.Unmarshal([]byte(data), &tmp)
+	if err != nil {
+		return err
+	}
+	*s = tmp 
+	return nil
+}
+
+type Config struct {
+    SomeData *SomeData `env:"SOME_DATA"`
+}
+
+func main() {
+	var cfg Config 
+	_, err := env.UnmarshalFromEnviron(&cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+    if cfg.SomeData != nil && cfg.SomeData.SomeField == 42 {
+        fmt.Println("Got 42!")
+    } else {
+        fmt.Printf("Got nil or some other value: %v\n", cfg.SomeData)
+    }
+}
+```

--- a/env.go
+++ b/env.go
@@ -262,14 +262,25 @@ func Marshal(v interface{}) (EnvSet, error) {
 
 		envKeys := strings.Split(tag, ",")
 
-		var envValue string
+		var el interface{}
 		if typeField.Type.Kind() == reflect.Ptr {
 			if valueField.IsNil() {
 				continue
 			}
-			envValue = fmt.Sprintf("%v", valueField.Elem().Interface())
+			el = valueField.Elem().Interface()
 		} else {
-			envValue = fmt.Sprintf("%v", valueField.Interface())
+			el = valueField.Interface()
+		}
+
+		var err error
+		var envValue string
+		if m, ok := el.(Marshaler); ok {
+			envValue, err = m.MarshalEnvironmentValue()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			envValue = fmt.Sprintf("%v", el)
 		}
 
 		for _, envKey := range envKeys {

--- a/env.go
+++ b/env.go
@@ -39,6 +39,8 @@ var (
 
 	// ErrMissingRequiredValue returned when a field with required=true contains no value or default
 	ErrMissingRequiredValue = errors.New("value for this field is required")
+
+	unmarshalType = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
 )
 
 // Unmarshal parses an EnvSet and stores the result in the value pointed to by
@@ -93,7 +95,7 @@ func Unmarshal(es EnvSet, v interface{}) error {
 
 		var (
 			envValue string
-			ok bool
+			ok       bool
 		)
 		for _, envKey := range envTag.Keys {
 			envValue, ok = es[envKey]
@@ -123,6 +125,37 @@ func Unmarshal(es EnvSet, v interface{}) error {
 }
 
 func set(t reflect.Type, f reflect.Value, value string) error {
+	// See if the type implements Unmarshaler and use that first,
+	// otherwise, fallback to the previous logic
+	var isUnmarshaler bool
+	isPtr := t.Kind() == reflect.Ptr
+	if isPtr {
+		isUnmarshaler = t.Implements(unmarshalType) && f.CanInterface()
+	} else if f.CanAddr() {
+		isUnmarshaler = f.Addr().Type().Implements(unmarshalType) && f.Addr().CanInterface()
+	}
+
+	if isUnmarshaler {
+		var ptr reflect.Value
+		if isPtr {
+			// In the pointer case, we need to create a new element to have an
+			// address to point to
+			ptr = reflect.New(t.Elem())
+		} else {
+			// And for scalars, we need the pointer to be able to modify the value
+			ptr = f.Addr()
+		}
+		if u, ok := ptr.Interface().(Unmarshaler); ok {
+			if err := u.UnmarshalEnvironmentValue(value); err != nil {
+				return err
+			}
+			if isPtr {
+				f.Set(ptr)
+			}
+			return nil
+		}
+	}
+
 	switch t.Kind() {
 	case reflect.Ptr:
 		ptr := reflect.New(t.Elem())
@@ -248,8 +281,8 @@ func Marshal(v interface{}) (EnvSet, error) {
 }
 
 type tag struct {
-	Keys []string
-	Default string
+	Keys     []string
+	Default  string
 	Required bool
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,6 @@
+package env
+
+// Marshaler is the interface implemented by types that can marshal themselves into valid environment variable values.
+type Marshaler interface {
+	MarshalEnvironmentValue() (string, error)
+}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -1,0 +1,8 @@
+package env
+
+// Unmarshaler is the interface implemented by types that can unmarshal an
+// environment variable value representation of themselves. The input can be
+// assumed to be the raw string value stored in the environment.
+type Unmarshaler interface {
+	UnmarshalEnvironmentValue(data string) error
+}


### PR DESCRIPTION
This lets you marshal/unmarshal custom types, like structs or scalars with
specific pre-processing steps required.  Docs/example are in the readme