### PR TITLE
Fix tiny typo in test

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -371,7 +371,7 @@ func TestUnmarshalRequiredValues(t *testing.T) {
 	var requiredValuesStruct RequiredValueStruct
 	err := Unmarshal(environ, &requiredValuesStruct)
 	if err != ErrMissingRequiredValue {
-		t.Errorf("Expected error 'ErrMissingRequiredValue' but go '%s'", err)
+		t.Errorf("Expected error 'ErrMissingRequiredValue' but got '%s'", err)
 	}
 	environ["REQUIRED_VAL"] = "required"
 	err = Unmarshal(environ, &requiredValuesStruct)


### PR DESCRIPTION
Just spotted this as I was trying to work out how to mock/override the ENV in my own test suite!