### PR TITLE
moving to go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Netflix/go-env
+
+go 1.13


### PR DESCRIPTION
This PR adds the `go.mod` file with the module name as `github.com/Netflix/go-env`