### PR TITLE
Convert string to int64 with ParseInt to prevent overflow on 32-bit systems

### DIFF
--- a/env.go
+++ b/env.go
@@ -190,7 +190,13 @@ func set(t reflect.Type, f reflect.Value, value string) error {
 			return err
 		}
 		f.SetFloat(v)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
+		v, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		f.SetInt(int64(v))
+	case reflect.Int64:
 		if t.PkgPath() == "time" && t.Name() == "Duration" {
 			duration, err := time.ParseDuration(value)
 			if err != nil {
@@ -201,11 +207,13 @@ func set(t reflect.Type, f reflect.Value, value string) error {
 			break
 		}
 
-		v, err := strconv.Atoi(value)
+		// Handling this separately because strconv.Atoi returns int,
+		// which is not guaranteed to be 64-bit on all platforms
+		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		f.SetInt(int64(v))
+		f.SetInt(v)
 	default:
 		return ErrUnsupportedType
 	}


### PR DESCRIPTION
`strconv.Atoi` returns an int, which isn't guaranteed to be 64-bit on all platforms. To prevent ints from overflowing on 32-bit platforms when setting int64 fields, strconv.ParseInt is used instead.