### PR TITLE
Make repo a Go module, switch to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.19', '1.20', '1.21', '1.22' ]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Build ${{ matrix.go-version }}
+      run: go build -v ./...
+
+    - name: Test ${{ matrix.go-version }}
+      run: go test -v ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,19 +10,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [ '1.19', '1.20', '1.21', '1.22' ]
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Go ${{ matrix.go-version }}
+    - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.22
 
-    - name: Build ${{ matrix.go-version }}
+    - name: Build
       run: go build -v ./...
 
-    - name: Test ${{ matrix.go-version }}
+    - name: Test
       run: go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-
-go:
-  - "1.10.2"
-  - master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-env
 
-[![Build Status](https://travis-ci.com/Netflix/go-env.svg?branch=master)](https://travis-ci.com/Netflix/go-env)
-[![GoDoc](https://godoc.org/github.com/Netflix/go-env?status.svg)](https://godoc.org/github.com/Netflix/go-env)
+![Build Status](https://github.com/Netflix/go-env/actions/workflows/build.yml/badge.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Netflix/go-env.svg)](https://pkg.go.dev/github.com/Netflix/go-env)
 [![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/Netflix/go-expect.svg)]()
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Netflix/go-env
+
+go 1.22.5


### PR DESCRIPTION
This PR adds a `go.mod` file with all relevant dependencies (none! :tada:) to support usage as a [Go Module](https://go.dev/ref/mod).

Netflix has largely transitioned off of Travis CI in favor of GitHub Actions. I replaced `.travis.yml` with a basic GHA workflow definition to build & test on recent Go versions.

Supersedes #19