### PR TITLE
Remove Go minor revision specification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Netflix/go-env
 
-go 1.22.5
+go 1.22


### PR DESCRIPTION
Specifying a Go minor revision forces all importers of the package to upgrade as well. Since I don't see any crucial benefit in enforcing this, I propose removing the requirement.