### PR TITLE
Add an example for an array value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ type Environment struct {
 	Duration      time.Duration `env:"TYPE_DURATION"`
 	DefaultValue  string        `env:"MISSING_VAR,default=default_value"`
 	RequiredValue string        `env:"IM_REQUIRED,required=true"`
+	ArrayValue    []string      `env:"ARRAY_VALUE,default=value1|value2|value3"`
 }
 
 func main() {


### PR DESCRIPTION
I saw somewhere on the internet that it works but couldn't remember how to separate the values.
It was not obvious to me how to separate the values.

After some searching I found it in the `env_test.go`.
https://github.com/Netflix/go-env/blob/131cef9fd1660019a633aebf343528bf68d312c9/env_test.go#L92

That's why I think it's good to show an example here.